### PR TITLE
allow exporting arrays in metaTasks

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,15 @@ function GulpDir(dir, args) {
       }
       for (var metaTask in module) {
         metaTasks[metaTask] = metaTasks[metaTask] || [];
-        metaTasks[metaTask].push(module[metaTask]);
+        
+        var tasks = module[metaTask];
+        if (!util.isArray(tasks)) {
+          tasks = [tasks];
+        }
+
+        tasks.forEach(function(task){
+          metaTasks[metaTask].push(task);
+        });
       }
     }
   }


### PR DESCRIPTION
allow multiple tasks to be exported as an array

```
var gulp = require('gulp');

gulp.task('test:a', function(cb){
  console.log('AAA');
});
gulp.task('test:b', function(cb){
  console.log('BBB');
});

module.exports = {  
  all: ['test:a','test:b']
};
```

the current alternative is:

```
var gulp = require('gulp');

gulp.task('test:a', function(cb){
  console.log('AAA');
});
gulp.task('test:b', function(cb){
  console.log('BBB');
});

gulp.task('test',['test:a','test:b']);

module.exports = {  
  all: 'test'
};
```
